### PR TITLE
♻️ refactor(niri): use typed Home Manager settings

### DIFF
--- a/docs/superpowers/plans/2026-07-10-typed-niri-configuration.md
+++ b/docs/superpowers/plans/2026-07-10-typed-niri-configuration.md
@@ -1,0 +1,411 @@
+# Typed Niri Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the raw Home Manager Niri KDL document with validated typed `programs.niri.settings` backed by niri-flake's unstable Niri package.
+
+**Architecture:** Add `niri-flake` as a Home Manager schema, package overlay, and Stylix provider while retaining the repository's NixOS/UWSM integration. The existing Home Manager module will derive typed settings from repository options and package paths, `homeModules.stylix` will supply Stylix defaults such as the cursor and border colors, and the config module imported by `homeModules.niri` will serialize and validate the resulting KDL.
+
+**Tech Stack:** Nix flakes, NixOS modules, Home Manager modules, niri-flake, UWSM, Jujutsu
+
+## Global Constraints
+
+- Use `pkgs.niri-unstable` and `pkgs.xwayland-satellite-unstable` from `niri.overlays.niri` for managed Home Manager sessions.
+- Import `niri.homeModules.niri` and `niri.homeModules.stylix`, disabling the Niri Stylix target on non-Linux systems; do not enable niri-flake's NixOS or binary-cache modules.
+- Preserve UWSM, portal, keyring, power-menu, startup, input, rule, and keybinding behavior while enabling integrated Xwayland Satellite.
+- Preserve the QWERTY and Page Up/Page Down workspace policy in `docs/keybinding-conventions.md`.
+- Remove only raw-KDL comments, commented examples, empty nodes, and disabled rules with no runtime effect.
+- Use `pvg1-nixos` as the representative Niri-enabled host.
+
+---
+
+### Task 1: Capture the Existing Generated Configuration
+
+**Files:**
+- Read: `modules/home-manager/window-manager/wayland/niri.nix`
+- Reference: `docs/keybinding-conventions.md`
+- Artifact: `/tmp/niri-config-before` (Nix result symlink, not committed)
+
+**Interfaces:**
+- Consumes: `nixosConfigurations.pvg1-nixos.config.home-manager.users.alexander.xdg.configFile."niri/config.kdl".source`
+- Produces: a realized pre-migration KDL reference used for semantic comparison
+
+- [ ] **Step 1: Realize the current generated KDL**
+
+Run:
+
+```bash
+nix build --out-link /tmp/niri-config-before '.#nixosConfigurations.pvg1-nixos.config.home-manager.users.alexander.xdg.configFile."niri/config.kdl".source'
+```
+
+Expected: exit 0 and `/tmp/niri-config-before` points to the validated current `niri-config.kdl` store path.
+
+- [ ] **Step 2: Confirm the reference contains repository-specific behavior**
+
+Run:
+
+```bash
+rg -n 'workspace-auto-back-and-forth|Mod\+Q|Mod\+Shift\+P|spawn-at-startup|Picture-in-Picture' /tmp/niri-config-before
+```
+
+Expected: all five patterns are present.
+
+---
+
+### Task 2: Add the niri-flake Modules and Package Overlay
+
+**Files:**
+- Modify: `flake.nix:72`
+- Modify: `flake.lock`
+- Modify: `overlays/default.nix`
+
+**Interfaces:**
+- Consumes: existing `nixpkgs` and `nixpkgs-stable` inputs
+- Produces: `flake.inputs.niri.homeModules.niri`, `flake.inputs.niri.homeModules.stylix`, and the Niri package overlay
+
+- [ ] **Step 1: Add the flake input**
+
+Insert after the `paneru` input in `flake.nix`:
+
+```nix
+niri = {
+  url = "github:sodiboo/niri-flake";
+  inputs = {
+    nixpkgs.follows = "nixpkgs";
+    nixpkgs-stable.follows = "nixpkgs-stable";
+  };
+};
+```
+
+- [ ] **Step 2: Apply the package overlay**
+
+Apply `inputs.niri.overlays.niri` in `overlays/default.nix` so the unstable Niri
+and Xwayland Satellite packages are available through the repository package set.
+
+- [ ] **Step 3: Lock the new input**
+
+Run:
+
+```bash
+nix flake lock --update-input niri
+```
+
+Expected: `flake.lock` gains `niri`, its Niri/Xwayland sources, and required transitive nodes without updating unrelated root inputs.
+
+- [ ] **Step 4: Verify the modules and overlay are available**
+
+Run:
+
+```bash
+nix flake metadata --json | jq -e '.locks.nodes.niri.locked.rev'
+```
+
+Expected: exit 0 with the locked niri-flake revision.
+
+- [ ] **Step 5: Format and inspect the dependency change**
+
+Run:
+
+```bash
+just lint flake.nix overlays/default.nix
+jj --no-pager diff --git
+```
+
+Expected: formatted Nix and a diff limited to the input, lock nodes, and package overlay.
+
+- [ ] **Step 6: Record the dependency revision and start the configuration revision**
+
+Run:
+
+```bash
+jj desc -m "❄️ build: add niri-flake config module"
+jj new -m "♻️ refactor(niri): use typed Home Manager settings"
+```
+
+Expected: the dependency changes remain in the parent and the new working-copy revision is empty.
+
+---
+
+### Task 3: Convert the Home Manager Module to Typed Settings
+
+**Files:**
+- Modify: `modules/home-manager/window-manager/wayland/niri.nix:1-742`
+- Verify: `modules/nixos/window-manager/wayland.nix:65-120`
+
+**Interfaces:**
+- Consumes: `flake.inputs.niri.homeModules.niri`, `flake.inputs.niri.homeModules.stylix`, `pkgs.niri-unstable`, `pkgs.xwayland-satellite-unstable`, repository keyboard/default-app/Stylix options, and executable paths
+- Produces: `programs.niri.package` and a complete `programs.niri.settings` value
+
+- [ ] **Step 1: Import the typed Home Manager schema and Stylix adapter**
+
+Add `flake` to the Home Manager module arguments and import the full Home Manager and Stylix modules. The explicit Stylix import is required because this repository imports Stylix inside Home Manager and disables its NixOS-to-Home-Manager auto-import. Disable its Niri target on non-Linux systems because the shared Home Manager module also evaluates on Darwin:
+
+```nix
+{
+  config,
+  flake,
+  lib,
+  pkgs,
+  ...
+}:
+```
+
+```nix
+imports = [
+  flake.inputs.niri.homeModules.niri
+  flake.inputs.niri.homeModules.stylix
+];
+
+config = lib.mkMerge [
+  (lib.mkIf (!pkgs.stdenv.hostPlatform.isLinux) {
+    stylix.targets.niri.enable = false;
+  })
+  (lib.mkIf cfg.enable {
+    # Niri configuration
+  })
+];
+```
+
+Keep `imports` at module top level and keep the non-Linux Stylix guard outside the Niri enable branch.
+
+- [ ] **Step 2: Select the managed unstable Niri package**
+
+Change the custom package default to:
+
+```nix
+default = pkgs.niri-unstable;
+defaultText = lib.literalExpression "pkgs.niri-unstable";
+```
+
+Inside the enabled Home Manager configuration set:
+
+```nix
+programs.niri = {
+  package = if cfg.package != null then cfg.package else pkgs.niri;
+  enable = cfg.package != null;
+  settings = typedSettings;
+};
+
+systemd.user.packages = lib.optional (cfg.package != null) cfg.package;
+```
+
+Leave the NixOS Niri launcher references as `pkgs.niri`. The UWSM `binPath`
+remains `/run/current-system/sw/bin/niri-session`, while Home Manager exposes the
+selected managed package's `niri.service`.
+
+- [ ] **Step 3: Define typed input, layout, rule, and environment settings**
+
+Create `typedSettings` in the Home Manager module `let` expression. It must contain these exact effective values:
+
+```nix
+typedSettings = {
+  input = {
+    keyboard = {
+      numlock = true;
+      xkb =
+        lib.optionalAttrs (layout != null) { inherit layout; }
+        // lib.optionalAttrs (variant != null) { inherit variant; }
+        // lib.optionalAttrs (xkbOptions != "") { options = xkbOptions; };
+    };
+    touchpad = {
+      tap = true;
+      dwt = true;
+      natural-scroll = true;
+      scroll-method = "two-finger";
+      middle-emulation = true;
+    };
+    mouse.accel-profile = "flat";
+    workspace-auto-back-and-forth = true;
+  };
+  layout = {
+    gaps = 8;
+    center-focused-column = "always";
+    preset-column-widths = map (proportion: { inherit proportion; }) [ 0.33333 0.5 0.66667 ];
+    default-column-width.proportion = 0.66667;
+    focus-ring = {
+      enable = true;
+      width = 2;
+    };
+    border = {
+      enable = false;
+      width = 2;
+    };
+    shadow = {
+      enable = false;
+      softness = 30;
+      spread = 5;
+      offset = { x = 0; y = 5; };
+    };
+  };
+  hotkey-overlay.skip-at-startup = true;
+  screenshot-path = "~/Pictures/Screenshots/%Y-%m-%d_%H-%M-%S-screenshot.png";
+  window-rules = [
+    {
+      matches = [ { app-id = "firefox$"; title = "^Picture-in-Picture$"; } ];
+      open-floating = true;
+    }
+  ];
+  environment = {
+    NIXOS_OZONE_WL = "1";
+    SDL_VIDEODRIVER = "wayland";
+    _JAVA_AWT_WM_NONREPARENTING = "1";
+  } // lib.optionalAttrs (config.i18n.inputMethod.enable && config.i18n.inputMethod.type == "fcitx5") {
+    XMODIFIERS = "@im=fcitx";
+  };
+  spawn-at-startup = [
+    { sh = "xrdb -merge ~/.Xresources"; }
+    { argv = [ (lib.getExe pkgs.swaybg) "-i" (toString config.stylix.image) "-m" wallpaperMode ]; }
+  ];
+  xwayland-satellite = {
+    enable = true;
+    path = lib.getExe pkgs.xwayland-satellite-unstable;
+  };
+};
+```
+
+The omitted focus-ring, urgent-border, and shadow colors match the pinned Niri
+defaults; Stylix continues to supply active and inactive border colors. If the
+current niri-flake type names differ during evaluation, use the documented typed
+equivalent; do not fall back to `programs.niri.config` or raw KDL.
+
+- [ ] **Step 4: Translate every active keybinding**
+
+Define each binding under `typedSettings.binds`. Use `action.<name>` for the action, plus `repeat`, `cooldown-ms`, `allow-inhibiting`, `allow-when-locked`, and `hotkey-overlay.title` where present.
+
+The binding map must include these exact groups:
+
+| Keys | Typed actions and metadata |
+| --- | --- |
+| `Mod+Ctrl+Slash` | `show-hotkey-overlay` |
+| `Mod+D`, `Mod+Return`, `Mod+M` | `spawn-sh` with menu, terminal, browser; retain overlay titles |
+| `Mod+Shift+Escape` | `spawn` power menu; title `Power Menu`; `allow-inhibiting = false` |
+| `Super+Alt+L` | `spawn` loginctl plus `lock-session`; title `Lock the Screen`; `allow-inhibiting = false` |
+| `XF86Audio*`, `XF86MonBrightness*` | current `spawn-sh` command strings; `allow-when-locked = true` |
+| `Mod+S`, `Mod+Shift+Slash` | `toggle-overview`, `close-window`; `repeat = false` |
+| Arrow and HJKL focus/move chords | current focus-column/window and move-column/window actions |
+| Home/End chords | focus first/last and move column first/last |
+| Ctrl+Arrow/HJKL | move workspace to monitor in the named direction |
+| Ctrl+Shift+Arrow/HJKL | focus monitor in the named direction |
+| Page Up/Page Down | focus workspace up/down; shifted forms move column up/down |
+| Wheel chords | current focus/move actions; preserve `cooldown-ms = 150` on vertical workspace chords |
+| `Mod+Q..P` | `focus-workspace` arguments 1 through 10 |
+| `Mod+Shift+Q..P` | `move-column-to-workspace` arguments 1 through 10 |
+| `Mod+Tab` | `focus-workspace-previous`; title `Switch Focus Between Workspaces` |
+| Brackets | consume-or-expel window left/right |
+| Period/height/layout chords | current preset width/height, reset, maximize, fullscreen, expand, and center actions |
+| Minus/Equal chords | `set-column-width` or `set-window-height` with current percentage strings |
+| Floating/tabbed chords | current toggle floating/focus and tabbed-display actions |
+| Print chords | screenshot, screenshot-screen, screenshot-window |
+| `Mod+Escape` | `toggle-keyboard-shortcuts-inhibit`; `allow-inhibiting = false` |
+| `Ctrl+Alt+Delete`, `Mod+Shift+Alt+P` | quit and power-off-monitors |
+
+Use generated Nix attrsets only for the two QWERTY workspace ranges when doing so keeps the key-to-index mapping explicit. All other bindings remain individually named for maintenance clarity.
+
+- [ ] **Step 5: Remove raw-KDL generation**
+
+Delete:
+
+- `quote = builtins.toJSON`;
+- the entire `xdg.configFile."niri/config.kdl".source = pkgs.writeTextFile { ... };` block;
+- all sample comments, commented KDL, empty animation/strut/window-rule nodes, and disabled example rules.
+
+Retain systemd user package exposure, the power-menu helper, `layout`, `variant`, `xkbOptions`, default apps, and wallpaper-derived values used by typed settings.
+
+- [ ] **Step 6: Format and evaluate the typed module**
+
+Run:
+
+```bash
+just lint modules/home-manager/window-manager/wayland/niri.nix modules/nixos/window-manager/wayland.nix
+nix eval '.#nixosConfigurations.pvg1-nixos.config.home-manager.users.alexander.programs.niri.finalConfig' --apply 'config: config != null'
+```
+
+Expected: formatting succeeds and the evaluation returns `true`.
+
+---
+
+### Task 4: Validate Semantic Parity and the Built System
+
+**Files:**
+- Verify: `flake.nix`
+- Verify: `flake.lock`
+- Verify: `modules/home-manager/window-manager/wayland/niri.nix`
+- Verify: `modules/nixos/window-manager/wayland.nix`
+- Verify: `docs/keybinding-conventions.md`
+- Artifact: `/tmp/niri-config-after` (Nix result symlink, not committed)
+
+**Interfaces:**
+- Consumes: the typed Home Manager configuration and its selected Niri package
+- Produces: validated generated KDL and a buildable `pvg1-nixos` system closure
+
+- [ ] **Step 1: Realize the typed generated KDL**
+
+Run:
+
+```bash
+nix build --out-link /tmp/niri-config-after '.#nixosConfigurations.pvg1-nixos.config.home-manager.users.alexander.xdg.configFile.niri-config.source'
+```
+
+Expected: exit 0; niri-flake's validation has accepted the generated file.
+
+- [ ] **Step 2: Validate directly with the selected package**
+
+Run:
+
+```bash
+$(nix build --no-link --print-out-paths '.#legacyPackages.x86_64-linux.niri-unstable')/bin/niri validate --config /tmp/niri-config-after
+```
+
+Expected: exit 0 with a valid configuration result.
+
+- [ ] **Step 3: Compare all active behavior**
+
+Run:
+
+```bash
+diff -u /tmp/niri-config-before /tmp/niri-config-after
+```
+
+Expected: textual differences are allowed because comments and serialization order change. Review every differing active node and confirm there is no missing input, layout, startup, environment, window-rule, or binding behavior.
+
+Run focused policy checks:
+
+```bash
+rg -n 'Mod\+Q|Mod\+P|Mod\+Shift\+Q|Mod\+Shift\+P|Mod\+Page_Down|Mod\+Shift\+Page_Down' /tmp/niri-config-after
+```
+
+Expected: all six representative bindings are present with the same actions as `docs/keybinding-conventions.md`.
+
+- [ ] **Step 4: Confirm UWSM ownership remains intact**
+
+Run:
+
+```bash
+nix eval --raw '.#nixosConfigurations.pvg1-nixos.config.programs.uwsm.waylandCompositors.niri.binPath'
+```
+
+Expected: `/run/current-system/sw/bin/niri-session`.
+
+- [ ] **Step 5: Run repository gates**
+
+Run:
+
+```bash
+just lint flake.nix modules/home-manager/window-manager/wayland/niri.nix modules/nixos/window-manager/wayland.nix
+just test flake.nix modules/home-manager/window-manager/wayland/niri.nix modules/nixos/window-manager/wayland.nix
+nix build '.#nixosConfigurations.pvg1-nixos.config.system.build.toplevel' --dry-run
+```
+
+Expected: all commands exit 0. The dry run evaluates the complete system and reports only required realizations/substitutions.
+
+- [ ] **Step 6: Review the final revisions**
+
+Run:
+
+```bash
+jj --no-pager st
+jj --no-pager diff --git -r @-
+jj --no-pager diff --git -r @
+```
+
+Expected: the PR changeset contains the niri-flake dependency and overlay, typed Niri module migration, and matching documentation. No unrelated files are modified.

--- a/docs/superpowers/specs/2026-07-10-typed-niri-configuration-design.md
+++ b/docs/superpowers/specs/2026-07-10-typed-niri-configuration-design.md
@@ -1,0 +1,126 @@
+# Typed Niri Configuration Migration
+
+## Goal
+
+Replace the hand-written KDL document in the Home Manager Niri module with
+`niri-flake`'s typed `programs.niri.settings` interface, use its unstable Niri
+and Xwayland Satellite packages for managed sessions, and keep UWSM responsible
+for session startup.
+
+## Scope
+
+The migration covers the Niri package source, Home Manager configuration
+generation, and the existing Niri settings. It does not replace the repository's
+NixOS session, portal, keyring, or UWSM integration and does not change the
+cross-platform keybinding policy.
+
+## Dependency Integration
+
+- Add `github:sodiboo/niri-flake` as the `niri` flake input.
+- Set `niri.inputs.nixpkgs.follows = "nixpkgs"` and
+  `niri.inputs.nixpkgs-stable.follows = "nixpkgs-stable"` to avoid redundant
+  package-set pins.
+- Apply `niri.overlays.niri` so `pkgs.niri-unstable` and
+  `pkgs.xwayland-satellite-unstable` are available in the repository package
+  set.
+- Continue using nixpkgs's `pkgs.niri` as the NixOS-installed launcher and as
+  the validation fallback when Home Manager is configured with `package = null`.
+- Do not enable `niri.nixosModules.niri` or its binary-cache option; use
+  `niri.homeModules.niri` for managed Home Manager sessions.
+
+## Module Architecture
+
+The existing NixOS module remains responsible for:
+
+- enabling UWSM and registering the Niri UWSM compositor entry;
+- installing the system Niri launcher and exposing its fallback systemd units;
+- configuring GNOME portals, GNOME Keyring, and the repository's portal
+  selection policy;
+- passing the repository's Niri enablement into Home Manager.
+
+The Home Manager Niri module imports `niri.homeModules.niri` and
+`niri.homeModules.stylix`. The explicit Stylix import is required because this
+repository imports Stylix inside Home Manager and disables its NixOS-to-Home
+Manager auto-import. The Niri Stylix target is disabled on non-Linux systems so
+the shared Home Manager module does not evaluate niri-flake's Linux package on
+Darwin. The module remains responsible for:
+
+- the repository-specific enable and nullable package options;
+- the Niri power-menu helper;
+- selecting the managed Niri package and exposing its systemd user units;
+- enabling integrated Xwayland Satellite with the matching unstable package;
+- translating repository settings and package paths into
+  `programs.niri.settings`.
+
+The generated configuration data flows as follows:
+
+1. Repository options, package paths, and the niri-flake Stylix adapter populate
+   `programs.niri.settings`.
+2. The config module imported by `niri.homeModules.niri` serializes those typed
+   values to KDL.
+3. The module validates the generated KDL with the selected Niri package,
+   defaulting to `pkgs.niri-unstable` and falling back to `pkgs.niri` when the
+   wrapper package is null.
+4. Home Manager installs the validated file as `$XDG_CONFIG_HOME/niri/config.kdl`.
+
+## Typed Settings Conversion
+
+Translate every effective setting from the current KDL document, omitting
+literal values that are identical to the pinned Niri defaults:
+
+- keyboard layout, variant, XKB options, numlock, pointer, and touchpad input;
+- workspace behavior and layout dimensions;
+- focus-ring, border, shadow, and geometry settings;
+- startup commands, screenshot path, hotkey overlay, and environment variables;
+- active window and layer rules;
+- every active keybinding, including command arguments and keybinding metadata.
+
+Remove sample comments, commented examples, empty nodes, and disabled rules that
+have no runtime effect. Import `niri.homeModules.stylix` so the cursor theme,
+cursor size, and active/inactive border colors follow Stylix automatically. The
+repository still controls focus-ring, border, and shadow enablement and geometry,
+while their redundant literal colors fall back to the pinned Niri defaults. The
+wallpaper command remains Stylix-derived.
+
+The workspace bindings must continue to match `docs/keybinding-conventions.md`:
+
+- `Mod+q..p` focuses workspaces 1 through 10;
+- `Mod+Shift+q..p` moves columns to workspaces 1 through 10;
+- Page Up and Page Down retain relative focus and move behavior.
+
+## Compatibility Decisions
+
+- Managed Home Manager sessions use `pkgs.niri-unstable` because integrated
+  Xwayland Satellite and the current typed actions require the matching unstable
+  schema and package. Build-time validation remains the compatibility gate.
+- UWSM remains the configured session-launch strategy and continues launching
+  `/run/current-system/sw/bin/niri-session`. For managed sessions, the Home
+  Manager-provided `niri.service` starts the selected unstable package.
+- Integrated Xwayland Satellite is enabled with
+  `pkgs.xwayland-satellite-unstable`; the former repository-specific Xwayland
+  option is removed.
+- The existing nullable package option is retained for compatibility. When it is
+  null, Home Manager still generates the typed configuration but omits Niri and
+  its systemd user units while validating against `pkgs.niri`.
+- Screenshots are saved under `~/Pictures/Screenshots`.
+
+## Validation
+
+Use `pvg1-nixos` as the representative Niri-enabled host.
+
+1. Before the conversion, realize and retain the current generated Niri config
+   as a behavioral reference.
+2. After the conversion, inspect the generated typed KDL and compare all active
+   settings and bindings against that reference. Serialization order and removed
+   comments are not required to match.
+3. Run `niri validate` against the realized typed configuration.
+4. Run targeted formatting/linting for the changed Nix files.
+5. Evaluate the flake and build the `pvg1-nixos` system closure.
+6. Confirm the generated UWSM compositor command still points to
+   `/run/current-system/sw/bin/niri-session`.
+
+## Non-goals
+
+- Enabling niri-flake's NixOS desktop stack or binary cache.
+- Changing keybindings, window-management behavior, portals, or session startup.
+- Refactoring unrelated Wayland modules.

--- a/flake.lock
+++ b/flake.lock
@@ -461,6 +461,66 @@
         "type": "github"
       }
     },
+    "niri": {
+      "inputs": {
+        "niri-stable": "niri-stable",
+        "niri-unstable": "niri-unstable",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nixpkgs-stable"
+        ],
+        "xwayland-satellite-stable": "xwayland-satellite-stable",
+        "xwayland-satellite-unstable": "xwayland-satellite-unstable"
+      },
+      "locked": {
+        "lastModified": 1783526091,
+        "narHash": "sha256-Zkkil0e8Wg5BcBmJkWJwBXlETefYQbYKw72xJUIBPLE=",
+        "owner": "sodiboo",
+        "repo": "niri-flake",
+        "rev": "a24d4c0dce53fd8dbeb9ad20411e282c7b9875f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sodiboo",
+        "repo": "niri-flake",
+        "type": "github"
+      }
+    },
+    "niri-stable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756556321,
+        "narHash": "sha256-RLD89dfjN0RVO86C/Mot0T7aduCygPGaYbog566F0Qo=",
+        "owner": "YaLTeR",
+        "repo": "niri",
+        "rev": "01be0e65f4eb91a9cd624ac0b76aaeab765c7294",
+        "type": "github"
+      },
+      "original": {
+        "owner": "YaLTeR",
+        "ref": "v25.08",
+        "repo": "niri",
+        "type": "github"
+      }
+    },
+    "niri-unstable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783522755,
+        "narHash": "sha256-dI0HkX1djETia7cD/Y64h8BNIsSOfTRMzfNum2J6UhE=",
+        "owner": "YaLTeR",
+        "repo": "niri",
+        "rev": "0777769e719b7c9b7c980d4ea66288bfbb4da5b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "YaLTeR",
+        "repo": "niri",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -753,6 +813,7 @@
         "jujutsu-skills": "jujutsu-skills",
         "lifewiki-skills": "lifewiki-skills",
         "llm-agents": "llm-agents",
+        "niri": "niri",
         "nix-darwin": "nix-darwin",
         "nix-flatpak": "nix-flatpak",
         "nix-proxy-manager": "nix-proxy-manager",
@@ -945,6 +1006,39 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "xwayland-satellite-stable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755491097,
+        "narHash": "sha256-m+9tUfsmBeF2Gn4HWa6vSITZ4Gz1eA1F5Kh62B0N4oE=",
+        "owner": "Supreeeme",
+        "repo": "xwayland-satellite",
+        "rev": "388d291e82ffbc73be18169d39470f340707edaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Supreeeme",
+        "ref": "v0.7",
+        "repo": "xwayland-satellite",
+        "type": "github"
+      }
+    },
+    "xwayland-satellite-unstable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781226823,
+        "narHash": "sha256-28696iIw8uE0ZUyFTtzhEM8xMh85clCYypMxkvUi+sc=",
+        "owner": "Supreeeme",
+        "repo": "xwayland-satellite",
+        "rev": "8575d0ef55d70f9b4c46b6bffb3accf912217e1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Supreeeme",
+        "repo": "xwayland-satellite",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,14 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    niri = {
+      url = "github:sodiboo/niri-flake";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        nixpkgs-stable.follows = "nixpkgs-stable";
+      };
+    };
+
     sops-nix = {
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/home-manager/window-manager/wayland/niri.nix
+++ b/modules/home-manager/window-manager/wayland/niri.nix
@@ -1,5 +1,6 @@
 {
   config,
+  flake,
   lib,
   pkgs,
   ...
@@ -39,704 +40,332 @@ let
       esac
     '';
   };
-  inherit (config.home-manager.window-manager.default) terminal;
-  inherit (config.home-manager.window-manager.default) browser;
+  inherit (config.home-manager.window-manager.default) terminal browser;
   wallpaperMode = config.stylix.imageScalingMode;
+  layout = if config.home.keyboard != null then config.home.keyboard.layout else null;
+  variant = if config.home.keyboard != null then config.home.keyboard.variant else null;
   xkbOptions =
     if config.home.keyboard != null then lib.concatStringsSep "," config.home.keyboard.options else "";
-  quote = builtins.toJSON;
+  action = name: {
+    action.${name} = [ ];
+  };
+  typedSettings = {
+    input = {
+      keyboard = {
+        numlock = true;
+        xkb =
+          lib.optionalAttrs (layout != null) { inherit layout; }
+          // lib.optionalAttrs (variant != null) { inherit variant; }
+          // lib.optionalAttrs (xkbOptions != "") { options = xkbOptions; };
+      };
+      touchpad = {
+        tap = true;
+        dwt = true;
+        natural-scroll = true;
+        scroll-method = "two-finger";
+        middle-emulation = true;
+      };
+      mouse.accel-profile = "flat";
+      workspace-auto-back-and-forth = true;
+    };
+
+    layout = {
+      gaps = 8;
+      center-focused-column = "always";
+      preset-column-widths = map (proportion: { inherit proportion; }) [
+        0.33333
+        0.5
+        0.66667
+      ];
+      default-column-width.proportion = 0.66667;
+      focus-ring = {
+        enable = true;
+        width = 2;
+      };
+      border = {
+        enable = false;
+        width = 2;
+      };
+      shadow = {
+        enable = false;
+        softness = 30;
+        spread = 5;
+        offset = {
+          x = 0;
+          y = 5;
+        };
+      };
+    };
+
+    spawn-at-startup = [
+      { sh = "xrdb -merge ~/.Xresources"; }
+      {
+        argv = [
+          (lib.getExe pkgs.swaybg)
+          "-i"
+          (toString config.stylix.image)
+          "-m"
+          wallpaperMode
+        ];
+      }
+    ];
+    hotkey-overlay.skip-at-startup = true;
+    screenshot-path = "~/Pictures/Screenshots/%Y-%m-%d_%H-%M-%S-screenshot.png";
+
+    window-rules = [
+      {
+        matches = [
+          {
+            app-id = "firefox$";
+            title = "^Picture-in-Picture$";
+          }
+        ];
+        open-floating = true;
+      }
+    ];
+
+    binds = {
+      "Mod+Ctrl+Slash" = action "show-hotkey-overlay";
+      "Mod+D" = {
+        action.spawn-sh = menu;
+        hotkey-overlay.title = "Run an Application";
+      };
+      "Mod+Return" = {
+        action.spawn-sh = terminal;
+        hotkey-overlay.title = "Open Terminal";
+      };
+      "Mod+M" = {
+        action.spawn-sh = browser;
+        hotkey-overlay.title = "Open Browser";
+      };
+      "Mod+Shift+Escape" = {
+        action.spawn = lib.getExe niriPowerMenu;
+        hotkey-overlay.title = "Power Menu";
+        allow-inhibiting = false;
+      };
+      "Super+Alt+L" = {
+        action.spawn = [
+          loginctl
+          "lock-session"
+        ];
+        hotkey-overlay.title = "Lock the Screen";
+        allow-inhibiting = false;
+      };
+
+      "XF86AudioRaiseVolume" = {
+        action.spawn-sh = "${lib.getExe pkgs.pamixer} --set-limit 150 --allow-boost -i 5";
+        allow-when-locked = true;
+      };
+      "XF86AudioLowerVolume" = {
+        action.spawn-sh = "${lib.getExe pkgs.pamixer} --set-limit 150 --allow-boost -d 5";
+        allow-when-locked = true;
+      };
+      "XF86AudioMute" = {
+        action.spawn-sh = "${lib.getExe pkgs.pamixer} --toggle-mute";
+        allow-when-locked = true;
+      };
+      "XF86AudioMicMute" = {
+        action.spawn-sh = "${lib.getExe pkgs.pamixer} --toggle-mute --default-source";
+        allow-when-locked = true;
+      };
+      "XF86AudioPlay" = {
+        action.spawn-sh = "${lib.getExe pkgs.playerctl} play-pause";
+        allow-when-locked = true;
+      };
+      "XF86AudioStop" = {
+        action.spawn-sh = "${lib.getExe pkgs.playerctl} stop";
+        allow-when-locked = true;
+      };
+      "XF86AudioPrev" = {
+        action.spawn-sh = "${lib.getExe pkgs.playerctl} previous";
+        allow-when-locked = true;
+      };
+      "XF86AudioNext" = {
+        action.spawn-sh = "${lib.getExe pkgs.playerctl} next";
+        allow-when-locked = true;
+      };
+      "XF86MonBrightnessUp" = {
+        action.spawn-sh = "${lib.getExe pkgs.brightnessctl} --class=backlight set +5%";
+        allow-when-locked = true;
+      };
+      "XF86MonBrightnessDown" = {
+        action.spawn-sh = "${lib.getExe pkgs.brightnessctl} --class=backlight set -5%";
+        allow-when-locked = true;
+      };
+
+      "Mod+S" = action "toggle-overview" // {
+        repeat = false;
+      };
+      "Mod+Shift+Slash" = action "close-window" // {
+        repeat = false;
+      };
+
+      "Mod+Left" = action "focus-column-left";
+      "Mod+Down" = action "focus-window-down";
+      "Mod+Up" = action "focus-window-up";
+      "Mod+Right" = action "focus-column-right";
+      "Mod+H" = action "focus-column-left";
+      "Mod+J" = action "focus-window-down";
+      "Mod+K" = action "focus-window-up";
+      "Mod+L" = action "focus-column-right";
+
+      "Mod+Shift+Left" = action "move-column-left";
+      "Mod+Shift+Down" = action "move-window-down";
+      "Mod+Shift+Up" = action "move-window-up";
+      "Mod+Shift+Right" = action "move-column-right";
+      "Mod+Shift+H" = action "move-column-left";
+      "Mod+Shift+J" = action "move-window-down";
+      "Mod+Shift+K" = action "move-window-up";
+      "Mod+Shift+L" = action "move-column-right";
+
+      "Mod+Home" = action "focus-column-first";
+      "Mod+End" = action "focus-column-last";
+      "Mod+Ctrl+Home" = action "move-column-to-first";
+      "Mod+Ctrl+End" = action "move-column-to-last";
+
+      "Mod+Ctrl+Left" = action "move-workspace-to-monitor-left";
+      "Mod+Ctrl+Down" = action "move-workspace-to-monitor-down";
+      "Mod+Ctrl+Up" = action "move-workspace-to-monitor-up";
+      "Mod+Ctrl+Right" = action "move-workspace-to-monitor-right";
+      "Mod+Ctrl+H" = action "move-workspace-to-monitor-left";
+      "Mod+Ctrl+J" = action "move-workspace-to-monitor-down";
+      "Mod+Ctrl+K" = action "move-workspace-to-monitor-up";
+      "Mod+Ctrl+L" = action "move-workspace-to-monitor-right";
+
+      "Mod+Ctrl+Shift+Left" = action "focus-monitor-left";
+      "Mod+Ctrl+Shift+Down" = action "focus-monitor-down";
+      "Mod+Ctrl+Shift+Up" = action "focus-monitor-up";
+      "Mod+Ctrl+Shift+Right" = action "focus-monitor-right";
+      "Mod+Ctrl+Shift+H" = action "focus-monitor-left";
+      "Mod+Ctrl+Shift+J" = action "focus-monitor-down";
+      "Mod+Ctrl+Shift+K" = action "focus-monitor-up";
+      "Mod+Ctrl+Shift+L" = action "focus-monitor-right";
+
+      "Mod+Page_Down" = action "focus-workspace-down";
+      "Mod+Page_Up" = action "focus-workspace-up";
+      "Mod+Shift+Page_Down" = action "move-column-to-workspace-down";
+      "Mod+Shift+Page_Up" = action "move-column-to-workspace-up";
+
+      "Mod+WheelScrollDown" = action "focus-workspace-down" // {
+        cooldown-ms = 150;
+      };
+      "Mod+WheelScrollUp" = action "focus-workspace-up" // {
+        cooldown-ms = 150;
+      };
+      "Mod+Ctrl+WheelScrollDown" = action "move-column-to-workspace-down" // {
+        cooldown-ms = 150;
+      };
+      "Mod+Ctrl+WheelScrollUp" = action "move-column-to-workspace-up" // {
+        cooldown-ms = 150;
+      };
+      "Mod+WheelScrollRight" = action "focus-column-right";
+      "Mod+WheelScrollLeft" = action "focus-column-left";
+      "Mod+Ctrl+WheelScrollRight" = action "move-column-right";
+      "Mod+Ctrl+WheelScrollLeft" = action "move-column-left";
+      "Mod+Shift+WheelScrollDown" = action "focus-column-right";
+      "Mod+Shift+WheelScrollUp" = action "focus-column-left";
+      "Mod+Ctrl+Shift+WheelScrollDown" = action "move-column-right";
+      "Mod+Ctrl+Shift+WheelScrollUp" = action "move-column-left";
+
+      "Mod+Q".action.focus-workspace = 1;
+      "Mod+W".action.focus-workspace = 2;
+      "Mod+E".action.focus-workspace = 3;
+      "Mod+R".action.focus-workspace = 4;
+      "Mod+T".action.focus-workspace = 5;
+      "Mod+Y".action.focus-workspace = 6;
+      "Mod+U".action.focus-workspace = 7;
+      "Mod+I".action.focus-workspace = 8;
+      "Mod+O".action.focus-workspace = 9;
+      "Mod+P".action.focus-workspace = 10;
+      "Mod+Shift+Q".action.move-column-to-workspace = 1;
+      "Mod+Shift+W".action.move-column-to-workspace = 2;
+      "Mod+Shift+E".action.move-column-to-workspace = 3;
+      "Mod+Shift+R".action.move-column-to-workspace = 4;
+      "Mod+Shift+T".action.move-column-to-workspace = 5;
+      "Mod+Shift+Y".action.move-column-to-workspace = 6;
+      "Mod+Shift+U".action.move-column-to-workspace = 7;
+      "Mod+Shift+I".action.move-column-to-workspace = 8;
+      "Mod+Shift+O".action.move-column-to-workspace = 9;
+      "Mod+Shift+P".action.move-column-to-workspace = 10;
+
+      "Mod+Tab" = action "focus-workspace-previous" // {
+        hotkey-overlay.title = "Switch Focus Between Workspaces";
+      };
+      "Mod+BracketLeft" = action "consume-or-expel-window-left";
+      "Mod+BracketRight" = action "consume-or-expel-window-right";
+      "Mod+Period" = action "switch-preset-column-width";
+      "Mod+Shift+Period" = action "switch-preset-window-height";
+      "Mod+Ctrl+Period" = action "reset-window-height";
+      "Mod+Ctrl+M" = action "maximize-column";
+      "Mod+F" = action "fullscreen-window";
+      "Mod+Shift+M" = action "maximize-window-to-edges" // {
+        hotkey-overlay.title = "Maximize Window";
+      };
+      "Mod+Ctrl+F" = action "expand-column-to-available-width";
+      "Mod+C" = action "center-column";
+      "Mod+Ctrl+C" = action "center-visible-columns";
+      "Mod+Minus".action.set-column-width = "-10%";
+      "Mod+Equal".action.set-column-width = "+10%";
+      "Mod+Shift+Minus".action.set-window-height = "-10%";
+      "Mod+Shift+Equal".action.set-window-height = "+10%";
+      "Mod+Shift+F" = action "toggle-window-floating";
+      "Mod+Shift+V" = action "switch-focus-between-floating-and-tiling";
+      "Mod+Ctrl+T" = action "toggle-column-tabbed-display";
+      "Print" = action "screenshot";
+      "Ctrl+Print" = action "screenshot-screen";
+      "Alt+Print" = action "screenshot-window";
+      "Mod+Escape" = action "toggle-keyboard-shortcuts-inhibit" // {
+        allow-inhibiting = false;
+      };
+      "Ctrl+Alt+Delete" = action "quit";
+      "Mod+Shift+Alt+P" = action "power-off-monitors";
+    };
+
+    environment = {
+      NIXOS_OZONE_WL = "1";
+      SDL_VIDEODRIVER = "wayland";
+      _JAVA_AWT_WM_NONREPARENTING = "1";
+    }
+    // lib.optionalAttrs (config.i18n.inputMethod.enable && config.i18n.inputMethod.type == "fcitx5") {
+      XMODIFIERS = "@im=fcitx";
+    };
+
+    xwayland-satellite = {
+      enable = true;
+      path = lib.getExe pkgs.xwayland-satellite-unstable;
+    };
+  };
 in
 {
+  imports = [
+    flake.inputs.niri.homeModules.niri
+    flake.inputs.niri.homeModules.stylix
+  ];
+
   options.home-manager.window-manager.wayland.niri = {
     enable = lib.mkEnableOption "Niri config" // {
       default = config.home-manager.window-manager.wayland.enable;
     };
     package = lib.mkOption {
       type = lib.types.nullOr lib.types.package;
-      default = pkgs.niri;
-      defaultText = lib.literalExpression "pkgs.niri";
+      default = pkgs.niri-unstable;
+      defaultText = lib.literalExpression "pkgs.niri-unstable";
       description = "The niri package to use. Set to null to use the system-provided package.";
     };
-    xwayland.enable = lib.mkEnableOption "X11 support via xwayland-satellite" // {
-      default = true;
-    };
   };
 
-  config = lib.mkIf cfg.enable {
-    home.packages =
-      with pkgs;
-      (lib.optional (cfg.package != null) cfg.package)
-      ++ [
-        niriPowerMenu
-      ]
-      ++ lib.optionals cfg.xwayland.enable [ xwayland-satellite ];
-
-    systemd.user.packages = lib.optional (cfg.package != null) cfg.package;
-
-    xdg.dataFile."wayland-sessions/niri.desktop" = lib.mkIf (cfg.package != null) {
-      source = "${cfg.package}/share/wayland-sessions/niri.desktop";
-    };
-
-    xdg.configFile."niri/config.kdl".source =
-      let
-        layout = if config.home.keyboard != null then config.home.keyboard.layout else null;
-        variant = if config.home.keyboard != null then config.home.keyboard.variant else null;
-        text = # kdl
-          ''
-            // This config is in the KDL format: https://kdl.dev
-            // "/-" comments out the following node.
-            // Check the wiki for a full description of the configuration:
-            // https://yalter.github.io/niri/Configuration:-Introduction
-
-            // Input device configuration.
-            // Find the full list of options on the wiki:
-            // https://yalter.github.io/niri/Configuration:-Input
-            input {
-                keyboard {
-                    xkb {
-                        // You can set rules, model, layout, variant and options.
-                        // For more information, see xkeyboard-config(7).
-
-                        // For example:
-                        // layout "us,ru"
-                        // options "grp:win_space_toggle,compose:ralt,ctrl:nocaps"
-
-                        // If this section is empty, niri will fetch xkb settings
-                        // from org.freedesktop.locale1. You can control these using
-                        // localectl set-x11-keymap.
-                        ${lib.optionalString (layout != null) "layout ${quote layout}"}
-                        ${lib.optionalString (variant != null) "variant ${quote variant}"}
-                        ${lib.optionalString (xkbOptions != "") "options ${quote xkbOptions}"}
-                    }
-
-                    // Enable numlock on startup, omitting this setting disables it.
-                    numlock
-                }
-
-                // Next sections include libinput settings.
-                // Omitting settings disables them, or leaves them at their default values.
-                // All commented-out settings here are examples, not defaults.
-                touchpad {
-                    // off
-                    tap
-                    dwt
-                    // dwtp
-                    // drag false
-                    // drag-lock
-                    natural-scroll
-                    // accel-speed 0.2
-                    // accel-profile "flat"
-                    scroll-method "two-finger"
-                    // disabled-on-external-mouse
-                    middle-emulation
-                }
-
-                mouse {
-                    // off
-                    // natural-scroll
-                    // accel-speed 0.2
-                    accel-profile "flat"
-                    // scroll-method "no-scroll"
-                }
-
-                trackpoint {
-                    // off
-                    // natural-scroll
-                    // accel-speed 0.2
-                    // accel-profile "flat"
-                    // scroll-method "on-button-down"
-                    // scroll-button 273
-                    // scroll-button-lock
-                    // middle-emulation
-                }
-
-                // Uncomment this to make the mouse warp to the center of newly focused windows.
-                // warp-mouse-to-focus
-
-                // Focus windows and outputs automatically when moving the mouse into them.
-                // Setting max-scroll-amount="0%" makes it work only on windows already fully on screen.
-                // focus-follows-mouse max-scroll-amount="0%"
-
-                workspace-auto-back-and-forth
-            }
-
-            // You can configure outputs by their name, which you can find
-            // by running `niri msg outputs` while inside a niri instance.
-            // The built-in laptop monitor is usually called "eDP-1".
-            // Find more information on the wiki:
-            // https://yalter.github.io/niri/Configuration:-Outputs
-            // Remember to uncomment the node by removing "/-"!
-            /-output "eDP-1" {
-                // Uncomment this line to disable this output.
-                // off
-
-                // Resolution and, optionally, refresh rate of the output.
-                // The format is "<width>x<height>" or "<width>x<height>@<refresh rate>".
-                // If the refresh rate is omitted, niri will pick the highest refresh rate
-                // for the resolution.
-                // If the mode is omitted altogether or is invalid, niri will pick one automatically.
-                // Run `niri msg outputs` while inside a niri instance to list all outputs and their modes.
-                mode "1920x1080@120.030"
-
-                // You can use integer or fractional scale, for example use 1.5 for 150% scale.
-                scale 2
-
-                // Transform allows to rotate the output counter-clockwise, valid values are:
-                // normal, 90, 180, 270, flipped, flipped-90, flipped-180 and flipped-270.
-                transform "normal"
-
-                // Position of the output in the global coordinate space.
-                // This affects directional monitor actions like "focus-monitor-left", and cursor movement.
-                // The cursor can only move between directly adjacent outputs.
-                // Output scale and rotation has to be taken into account for positioning:
-                // outputs are sized in logical, or scaled, pixels.
-                // For example, a 3840×2160 output with scale 2.0 will have a logical size of 1920×1080,
-                // so to put another output directly adjacent to it on the right, set its x to 1920.
-                // If the position is unset or results in an overlap, the output is instead placed
-                // automatically.
-                position x=1280 y=0
-            }
-
-            // Settings that influence how windows are positioned and sized.
-            // Find more information on the wiki:
-            // https://yalter.github.io/niri/Configuration:-Layout
-            layout {
-                // Set gaps around windows in logical pixels.
-                gaps 8
-
-                // When to center a column when changing focus, options are:
-                // - "never", default behavior, focusing an off-screen column will keep at the left
-                //   or right edge of the screen.
-                // - "always", the focused column will always be centered.
-                // - "on-overflow", focusing a column will center it if it doesn't fit
-                //   together with the previously focused column.
-                center-focused-column "always"
-
-                // You can customize the widths that "switch-preset-column-width" (Mod+R) toggles between.
-                preset-column-widths {
-                    // Proportion sets the width as a fraction of the output width, taking gaps into account.
-                    // For example, you can perfectly fit four windows sized "proportion 0.25" on an output.
-                    // The default preset widths are 1/3, 1/2 and 2/3 of the output.
-                    proportion 0.33333
-                    proportion 0.5
-                    proportion 0.66667
-
-                    // Fixed sets the width in logical pixels exactly.
-                    // fixed 1920
-                }
-
-                // You can also customize the heights that "switch-preset-window-height" (Mod+Shift+R) toggles between.
-                // preset-window-heights { }
-
-                // You can change the default width of the new windows.
-                default-column-width { proportion 0.66667; }
-                // If you leave the brackets empty, the windows themselves will decide their initial width.
-                // default-column-width {}
-
-                // By default focus ring and border are rendered as a solid background rectangle
-                // behind windows. That is, they will show up through semitransparent windows.
-                // This is because windows using client-side decorations can have an arbitrary shape.
-                //
-                // If you don't like that, you should uncomment `prefer-no-csd` below.
-                // Niri will draw focus ring and border *around* windows that agree to omit their
-                // client-side decorations.
-                //
-                // Alternatively, you can override it with a window rule called
-                // `draw-border-with-background`.
-
-                // You can change how the focus ring looks.
-                focus-ring {
-                    // Uncomment this line to disable the focus ring.
-                    // off
-
-                    // How many logical pixels the ring extends out from the windows.
-                    width 2
-
-                    // Colors can be set in a variety of ways:
-                    // - CSS named colors: "red"
-                    // - RGB hex: "#rgb", "#rgba", "#rrggbb", "#rrggbbaa"
-                    // - CSS-like notation: "rgb(255, 127, 0)", rgba(), hsl() and a few others.
-
-                    // Color of the ring on the active monitor.
-                    active-color "#7fc8ff"
-
-                    // Color of the ring on inactive monitors.
-                    //
-                    // The focus ring only draws around the active window, so the only place
-                    // where you can see its inactive-color is on other monitors.
-                    inactive-color "#505050"
-
-                    // You can also use gradients. They take precedence over solid colors.
-                    // Gradients are rendered the same as CSS linear-gradient(angle, from, to).
-                    // The angle is the same as in linear-gradient, and is optional,
-                    // defaulting to 180 (top-to-bottom gradient).
-                    // You can use any CSS linear-gradient tool on the web to set these up.
-                    // Changing the color space is also supported, check the wiki for more info.
-                    //
-                    // active-gradient from="#80c8ff" to="#c7ff7f" angle=45
-
-                    // You can also color the gradient relative to the entire view
-                    // of the workspace, rather than relative to just the window itself.
-                    // To do that, set relative-to="workspace-view".
-                    //
-                    // inactive-gradient from="#505050" to="#808080" angle=45 relative-to="workspace-view"
-                }
-
-                // You can also add a border. It's similar to the focus ring, but always visible.
-                border {
-                    // The settings are the same as for the focus ring.
-                    // If you enable the border, you probably want to disable the focus ring.
-                    off
-
-                    width 2
-                    active-color "#ffc87f"
-                    inactive-color "#505050"
-
-                    // Color of the border around windows that request your attention.
-                    urgent-color "#9b0000"
-
-                    // Gradients can use a few different interpolation color spaces.
-                    // For example, this is a pastel rainbow gradient via in="oklch longer hue".
-                    //
-                    // active-gradient from="#e5989b" to="#ffb4a2" angle=45 relative-to="workspace-view" in="oklch longer hue"
-
-                    // inactive-gradient from="#505050" to="#808080" angle=45 relative-to="workspace-view"
-                }
-
-                // You can enable drop shadows for windows.
-                shadow {
-                    // Uncomment the next line to enable shadows.
-                    // on
-
-                    // By default, the shadow draws only around its window, and not behind it.
-                    // Uncomment this setting to make the shadow draw behind its window.
-                    //
-                    // Note that niri has no way of knowing about the CSD window corner
-                    // radius. It has to assume that windows have square corners, leading to
-                    // shadow artifacts inside the CSD rounded corners. This setting fixes
-                    // those artifacts.
-                    //
-                    // However, instead you may want to set prefer-no-csd and/or
-                    // geometry-corner-radius. Then, niri will know the corner radius and
-                    // draw the shadow correctly, without having to draw it behind the
-                    // window. These will also remove client-side shadows if the window
-                    // draws any.
-                    //
-                    // draw-behind-window true
-
-                    // You can change how shadows look. The values below are in logical
-                    // pixels and match the CSS box-shadow properties.
-
-                    // Softness controls the shadow blur radius.
-                    softness 30
-
-                    // Spread expands the shadow.
-                    spread 5
-
-                    // Offset moves the shadow relative to the window.
-                    offset x=0 y=5
-
-                    // You can also change the shadow color and opacity.
-                    color "#0007"
-                }
-
-                // Struts shrink the area occupied by windows, similarly to layer-shell panels.
-                // You can think of them as a kind of outer gaps. They are set in logical pixels.
-                // Left and right struts will cause the next window to the side to always be visible.
-                // Top and bottom struts will simply add outer gaps in addition to the area occupied by
-                // layer-shell panels and regular gaps.
-                struts {
-                    // left 64
-                    // right 64
-                    // top 64
-                    // bottom 64
-                }
-            }
-
-            // Add lines like this to spawn processes at startup.
-            // Note that running niri as a session supports xdg-desktop-autostart,
-            // which may be more convenient to use.
-            // See the binds section below for more spawn examples.
-
-            // This line starts waybar, a commonly used bar for Wayland compositors.
-            // spawn-at-startup "waybar"
-
-            // To run a shell command (with variables, pipes, etc.), use spawn-sh-at-startup:
-            // spawn-sh-at-startup "qs -c ~/source/qs/MyAwesomeShell"
-            spawn-sh-at-startup "xrdb -merge ~/.Xresources"
-
-            hotkey-overlay {
-                // Uncomment this line to disable the "Important Hotkeys" pop-up at startup.
-                skip-at-startup
-            }
-
-            // Uncomment this line to ask the clients to omit their client-side decorations if possible.
-            // If the client will specifically ask for CSD, the request will be honored.
-            // Additionally, clients will be informed that they are tiled, removing some client-side rounded corners.
-            // This option will also fix border/focus ring drawing behind some semitransparent windows.
-            // After enabling or disabling this, you need to restart the apps for this to take effect.
-            // prefer-no-csd
-
-            // You can change the path where screenshots are saved.
-            // A ~ at the front will be expanded to the home directory.
-            // The path is formatted with strftime(3) to give you the screenshot date and time.
-            screenshot-path "~/Pictures/%Y-%m-%d_%H-%M-%S-screenshot.png"
-
-            // You can also set this to null to disable saving screenshots to disk.
-            // screenshot-path null
-
-            // Animation settings.
-            // The wiki explains how to configure individual animations:
-            // https://yalter.github.io/niri/Configuration:-Animations
-            animations {
-                // Uncomment to turn off all animations.
-                // off
-
-                // Slow down all animations by this factor. Values below 1 speed them up instead.
-                // slowdown 3.0
-            }
-
-            // Window rules let you adjust behavior for individual windows.
-            // Find more information on the wiki:
-            // https://yalter.github.io/niri/Configuration:-Window-Rules
-
-            // Work around WezTerm's initial configure bug
-            // by setting an empty default-column-width.
-            window-rule {
-                // This regular expression is intentionally made as specific as possible,
-                // since this is the default config, and we want no false positives.
-                // You can get away with just app-id="wezterm" if you want.
-                // match app-id=r#"^org\.wezfurlong\.wezterm$"#
-                // default-column-width {}
-            }
-
-            // Open the Firefox picture-in-picture player as floating by default.
-            window-rule {
-                // This app-id regular expression will work for both:
-                // - host Firefox (app-id is "firefox")
-                // - Flatpak Firefox (app-id is "org.mozilla.firefox")
-                match app-id=r#"firefox$"# title="^Picture-in-Picture$"
-                open-floating true
-            }
-
-            // Example: block out two password managers from screen capture.
-            // (This example rule is commented out with a "/-" in front.)
-            /-window-rule {
-                match app-id=r#"^org\.keepassxc\.KeePassXC$"#
-                match app-id=r#"^org\.gnome\.World\.Secrets$"#
-
-                block-out-from "screen-capture"
-
-                // Use this instead if you want them visible on third-party screenshot tools.
-                // block-out-from "screencast"
-            }
-
-            // Example: enable rounded corners for all windows.
-            // (This example rule is commented out with a "/-" in front.)
-            /-window-rule {
-                geometry-corner-radius 12
-                clip-to-geometry true
-            }
-
-            binds {
-                // Keys consist of modifiers separated by + signs, followed by an XKB key name
-                // in the end. To find an XKB name for a particular key, you may use a program
-                // like wev.
-                //
-                // "Mod" is a special modifier equal to Super when running on a TTY, and to Alt
-                // when running as a winit window.
-                //
-                // Most actions that you can bind here can also be invoked programmatically with
-                // `niri msg action do-something`.
-
-                // Mod-Shift-/, which is usually the same as Mod-?,
-                // shows a list of important hotkeys.
-                Mod+Ctrl+Slash { show-hotkey-overlay; }
-
-                // Suggested binds for running programs: terminal, app launcher, screen locker.
-                // Mod+T hotkey-overlay-title="Open a Terminal: alacritty" { spawn "alacritty"; }
-                Mod+D hotkey-overlay-title="Run an Application" { spawn-sh ${quote menu}; }
-                Mod+Return hotkey-overlay-title="Open Terminal" { spawn-sh ${quote terminal}; }
-                Mod+M hotkey-overlay-title="Open Browser" { spawn-sh ${quote browser}; }
-                // Those bindings will always work, even when using a virtual machine.
-                Mod+Shift+Escape hotkey-overlay-title="Power Menu" allow-inhibiting=false { spawn ${quote (lib.getExe niriPowerMenu)}; }
-                Super+Alt+L hotkey-overlay-title="Lock the Screen" allow-inhibiting=false { spawn ${quote loginctl} "lock-session"; }
-
-                // Use spawn-sh to run a shell command. Do this if you need pipes, multiple commands, etc.
-                // Note: the entire command goes as a single argument. It's passed verbatim to `sh -c`.
-                // For example, this is a standard bind to toggle the screen reader (orca).
-                // Super+Alt+S allow-when-locked=true hotkey-overlay-title=null { spawn-sh "pkill orca || exec orca"; }
-
-                // Example volume keys mappings for PipeWire & WirePlumber.
-                // The allow-when-locked=true property makes them work even when the session is locked.
-                // Using spawn-sh allows to pass multiple arguments together with the command.
-                // "-l 1.0" limits the volume to 100%.
-                XF86AudioRaiseVolume allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.pamixer} --set-limit 150 --allow-boost -i 5"}; }
-                XF86AudioLowerVolume allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.pamixer} --set-limit 150 --allow-boost -d 5"}; }
-                XF86AudioMute        allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.pamixer} --toggle-mute"}; }
-                XF86AudioMicMute     allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.pamixer} --toggle-mute --default-source"}; }
-
-                // Example media keys mapping using playerctl.
-                // This will work with any MPRIS-enabled media player.
-                XF86AudioPlay        allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.playerctl} play-pause"}; }
-                XF86AudioStop        allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.playerctl} stop"}; }
-                XF86AudioPrev        allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.playerctl} previous"}; }
-                XF86AudioNext        allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.playerctl} next"}; }
-
-                // Example brightness key mappings for brightnessctl.
-                // You can use regular spawn with multiple arguments too (to avoid going through "sh"),
-                // but you need to manually put each argument in separate "" quotes.
-                XF86MonBrightnessUp allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.brightnessctl} --class=backlight set +5%"}; }
-                XF86MonBrightnessDown allow-when-locked=true { spawn-sh ${quote "${lib.getExe pkgs.brightnessctl} --class=backlight set -5%"}; }
-
-                // Open/close the Overview: a zoomed-out view of workspaces and windows.
-                // You can also move the mouse into the top-left hot corner,
-                // or do a four-finger swipe up on a touchpad.
-                Mod+S repeat=false { toggle-overview; }
-
-                Mod+Shift+Slash repeat=false { close-window; }
-
-                Mod+Left  { focus-column-left; }
-                Mod+Down  { focus-window-down; }
-                Mod+Up    { focus-window-up; }
-                Mod+Right { focus-column-right; }
-                Mod+H     { focus-column-left; }
-                Mod+J     { focus-window-down; }
-                Mod+K     { focus-window-up; }
-                Mod+L     { focus-column-right; }
-
-                Mod+Shift+Left  { move-column-left; }
-                Mod+Shift+Down  { move-window-down; }
-                Mod+Shift+Up    { move-window-up; }
-                Mod+Shift+Right { move-column-right; }
-                Mod+Shift+H     { move-column-left; }
-                Mod+Shift+J     { move-window-down; }
-                Mod+Shift+K     { move-window-up; }
-                Mod+Shift+L     { move-column-right; }
-
-                // Alternative commands that move across workspaces when reaching
-                // the first or last window in a column.
-                // Mod+J     { focus-window-or-workspace-down; }
-                // Mod+K     { focus-window-or-workspace-up; }
-                // Mod+Ctrl+J     { move-window-down-or-to-workspace-down; }
-                // Mod+Ctrl+K     { move-window-up-or-to-workspace-up; }
-
-                Mod+Home { focus-column-first; }
-                Mod+End  { focus-column-last; }
-                Mod+Ctrl+Home { move-column-to-first; }
-                Mod+Ctrl+End  { move-column-to-last; }
-
-                Mod+Ctrl+Left  { move-workspace-to-monitor-left; }
-                Mod+Ctrl+Down  { move-workspace-to-monitor-down; }
-                Mod+Ctrl+Up    { move-workspace-to-monitor-up; }
-                Mod+Ctrl+Right { move-workspace-to-monitor-right; }
-                Mod+Ctrl+H     { move-workspace-to-monitor-left; }
-                Mod+Ctrl+J     { move-workspace-to-monitor-down; }
-                Mod+Ctrl+K     { move-workspace-to-monitor-up; }
-                Mod+Ctrl+L     { move-workspace-to-monitor-right; }
-
-                Mod+Ctrl+Shift+Left  { focus-monitor-left; }
-                Mod+Ctrl+Shift+Down  { focus-monitor-down; }
-                Mod+Ctrl+Shift+Up    { focus-monitor-up; }
-                Mod+Ctrl+Shift+Right { focus-monitor-right; }
-                Mod+Ctrl+Shift+H     { focus-monitor-left; }
-                Mod+Ctrl+Shift+J     { focus-monitor-down; }
-                Mod+Ctrl+Shift+K     { focus-monitor-up; }
-                Mod+Ctrl+Shift+L     { focus-monitor-right; }
-
-                // Alternatively, there are commands to move just a single window:
-                // Mod+Shift+Ctrl+Left  { move-window-to-monitor-left; }
-                // ...
-
-                // And you can also move a single column to another monitor:
-                // Mod+Shift+Ctrl+Left  { move-column-to-monitor-left; }
-                // ...
-
-                Mod+Page_Down      { focus-workspace-down; }
-                Mod+Page_Up        { focus-workspace-up; }
-
-                // Alternatively, there are commands to move just a single window:
-                // Mod+Shift+Page_Down { move-window-to-workspace-down; }
-                // ...
-
-                Mod+Shift+Page_Down { move-column-to-workspace-down; }
-                Mod+Shift+Page_Up   { move-column-to-workspace-up; }
-                // Mod+Shift+U         { move-workspace-down; }
-                // Mod+Shift+I         { move-workspace-up; }
-
-                // You can bind mouse wheel scroll ticks using the following syntax.
-                // These binds will change direction based on the natural-scroll setting.
-                //
-                // To avoid scrolling through workspaces really fast, you can use
-                // the cooldown-ms property. The bind will be rate-limited to this value.
-                // You can set a cooldown on any bind, but it's most useful for the wheel.
-                Mod+WheelScrollDown      cooldown-ms=150 { focus-workspace-down; }
-                Mod+WheelScrollUp        cooldown-ms=150 { focus-workspace-up; }
-                Mod+Ctrl+WheelScrollDown cooldown-ms=150 { move-column-to-workspace-down; }
-                Mod+Ctrl+WheelScrollUp   cooldown-ms=150 { move-column-to-workspace-up; }
-
-                Mod+WheelScrollRight      { focus-column-right; }
-                Mod+WheelScrollLeft       { focus-column-left; }
-                Mod+Ctrl+WheelScrollRight { move-column-right; }
-                Mod+Ctrl+WheelScrollLeft  { move-column-left; }
-
-                // Usually scrolling up and down with Shift in applications results in
-                // horizontal scrolling; these binds replicate that.
-                Mod+Shift+WheelScrollDown      { focus-column-right; }
-                Mod+Shift+WheelScrollUp        { focus-column-left; }
-                Mod+Ctrl+Shift+WheelScrollDown { move-column-right; }
-                Mod+Ctrl+Shift+WheelScrollUp   { move-column-left; }
-
-                // Similarly, you can bind touchpad scroll "ticks".
-                // Touchpad scrolling is continuous, so for these binds it is split into
-                // discrete intervals.
-                // These binds are also affected by touchpad's natural-scroll, so these
-                // example binds are "inverted", since we have natural-scroll enabled for
-                // touchpads by default.
-                // Mod+TouchpadScrollDown { spawn-sh "wpctl set-volume @DEFAULT_AUDIO_SINK@ 0.02+"; }
-                // Mod+TouchpadScrollUp   { spawn-sh "wpctl set-volume @DEFAULT_AUDIO_SINK@ 0.02-"; }
-
-                // You can refer to workspaces by index. However, keep in mind that
-                // niri is a dynamic workspace system, so these commands are kind of
-                // "best effort". Trying to refer to a workspace index bigger than
-                // the current workspace count will instead refer to the bottommost
-                // (empty) workspace.
-                //
-                // For example, with 2 workspaces + 1 empty, indices 3, 4, 5 and so on
-                // will all refer to the 3rd workspace.
-                Mod+Q { focus-workspace 1; }
-                Mod+W { focus-workspace 2; }
-                Mod+E { focus-workspace 3; }
-                Mod+R { focus-workspace 4; }
-                Mod+T { focus-workspace 5; }
-                Mod+Y { focus-workspace 6; }
-                Mod+U { focus-workspace 7; }
-                Mod+I { focus-workspace 8; }
-                Mod+O { focus-workspace 9; }
-                Mod+P { focus-workspace 10; }
-                Mod+Shift+Q { move-column-to-workspace 1; }
-                Mod+Shift+W { move-column-to-workspace 2; }
-                Mod+Shift+E { move-column-to-workspace 3; }
-                Mod+Shift+R { move-column-to-workspace 4; }
-                Mod+Shift+T { move-column-to-workspace 5; }
-                Mod+Shift+Y { move-column-to-workspace 6; }
-                Mod+Shift+U { move-column-to-workspace 7; }
-                Mod+Shift+I { move-column-to-workspace 8; }
-                Mod+Shift+O { move-column-to-workspace 9; }
-                Mod+Shift+P { move-column-to-workspace 10; }
-
-                // Alternatively, there are commands to move just a single window:
-                // Mod+Ctrl+1 { move-window-to-workspace 1; }
-
-                // Switches focus between the current and the previous workspace.
-                Mod+Tab hotkey-overlay-title="Switch Focus Between Workspaces" { focus-workspace-previous; }
-
-                // The following binds move the focused window in and out of a column.
-                // If the window is alone, they will consume it into the nearby column to the side.
-                // If the window is already in a column, they will expel it out.
-                Mod+BracketLeft  { consume-or-expel-window-left; }
-                Mod+BracketRight { consume-or-expel-window-right; }
-
-                // Consume one window from the right to the bottom of the focused column.
-                // Mod+Comma  { consume-window-into-column; }
-                // Expel the bottom window from the focused column to the right.
-                // Mod+Period { expel-window-from-column; }
-
-                Mod+Period { switch-preset-column-width; }
-                // Cycling through the presets in reverse order is also possible.
-                // Mod+Period { switch-preset-column-width-back; }
-                Mod+Shift+Period { switch-preset-window-height; }
-                Mod+Ctrl+Period { reset-window-height; }
-                Mod+Ctrl+M { maximize-column; }
-                Mod+F { fullscreen-window; }
-
-                // While maximize-column leaves gaps and borders around the window,
-                // maximize-window-to-edges doesn't: the window expands to the edges of the screen.
-                // This bind corresponds to normal window maximizing,
-                // e.g. by double-clicking on the titlebar.
-                Mod+Shift+M hotkey-overlay-title="Maximize Window" { maximize-window-to-edges; }
-
-                // Expand the focused column to space not taken up by other fully visible columns.
-                // Makes the column "fill the rest of the space".
-                Mod+Ctrl+F { expand-column-to-available-width; }
-
-                Mod+C { center-column; }
-
-                // Center all fully visible columns on screen.
-                Mod+Ctrl+C { center-visible-columns; }
-
-                // Finer width adjustments.
-                // This command can also:
-                // * set width in pixels: "1000"
-                // * adjust width in pixels: "-5" or "+5"
-                // * set width as a percentage of screen width: "25%"
-                // * adjust width as a percentage of screen width: "-10%" or "+10%"
-                // Pixel sizes use logical, or scaled, pixels. I.e. on an output with scale 2.0,
-                // set-column-width "100" will make the column occupy 200 physical screen pixels.
-                Mod+Minus { set-column-width "-10%"; }
-                Mod+Equal { set-column-width "+10%"; }
-
-                // Finer height adjustments when in column with other windows.
-                Mod+Shift+Minus { set-window-height "-10%"; }
-                Mod+Shift+Equal { set-window-height "+10%"; }
-
-                // Move the focused window between the floating and the tiling layout.
-                Mod+Shift+F { toggle-window-floating; }
-                Mod+Shift+V { switch-focus-between-floating-and-tiling; }
-
-                // Toggle tabbed column display mode.
-                // Windows in this column will appear as vertical tabs,
-                // rather than stacked on top of each other.
-                Mod+Ctrl+T { toggle-column-tabbed-display; }
-
-                // Actions to switch layouts.
-                // Note: if you uncomment these, make sure you do NOT have
-                // a matching layout switch hotkey configured in xkb options above.
-                // Having both at once on the same hotkey will break the switching,
-                // since it will switch twice upon pressing the hotkey (once by xkb, once by niri).
-                // Mod+Space       { switch-layout "next"; }
-                // Mod+Shift+Space { switch-layout "prev"; }
-
-                Print { screenshot; }
-                Ctrl+Print { screenshot-screen; }
-                Alt+Print { screenshot-window; }
-
-                // Applications such as remote-desktop clients and software KVM switches may
-                // request that niri stops processing the keyboard shortcuts defined here
-                // so they may, for example, forward the key presses as-is to a remote machine.
-                // It's a good idea to bind an escape hatch to toggle the inhibitor,
-                // so a buggy application can't hold your session hostage.
-                //
-                // The allow-inhibiting=false property can be applied to other binds as well,
-                // which ensures niri always processes them, even when an inhibitor is active.
-                Mod+Escape allow-inhibiting=false { toggle-keyboard-shortcuts-inhibit; }
-
-                // The quit action will show a confirmation dialog to avoid accidental exits.
-                Ctrl+Alt+Delete { quit; }
-
-                // Powers off the monitors. To turn them back on, do any input like
-                // moving the mouse or pressing any other key.
-                Mod+Shift+Alt+P { power-off-monitors; }
-            }
-
-            environment {
-                NIXOS_OZONE_WL "1"
-                SDL_VIDEODRIVER "wayland"
-                _JAVA_AWT_WM_NONREPARENTING "1"
-                ${lib.optionalString (
-                  config.i18n.inputMethod.enable && config.i18n.inputMethod.type == "fcitx5"
-                ) ''XMODIFIERS "@im=fcitx"''}
-            }
-
-            spawn-at-startup ${quote (lib.getExe pkgs.swaybg)} "-i" ${quote config.stylix.image} "-m" ${quote wallpaperMode}
-          '';
-      in
-      pkgs.writeTextFile {
-        name = "niri-config.kdl";
-        inherit text;
-        checkPhase = ''
-          ${niri} validate --config "$target"
-        '';
+  config = lib.mkMerge [
+    (lib.mkIf (!pkgs.stdenv.hostPlatform.isLinux) {
+      stylix.targets.niri.enable = false;
+    })
+    (lib.mkIf cfg.enable {
+      programs.niri = {
+        package = if cfg.package != null then cfg.package else pkgs.niri;
+        enable = cfg.package != null;
+        settings = typedSettings;
       };
-  };
+
+      systemd.user.packages = lib.optional (cfg.package != null) cfg.package;
+    })
+  ];
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -4,9 +4,11 @@ final: prev:
 let
   nurOverlay = inputs.nur.overlays.default final prev;
   llmAgentsOverlay = inputs.llm-agents.overlays.default final prev;
+  niriOverlay = inputs.niri.overlays.niri final prev;
 in
 nurOverlay
 // llmAgentsOverlay
+// niriOverlay
 // (
   let
     inherit (prev.stdenv.hostPlatform) system;


### PR DESCRIPTION
## Summary

- add `niri-flake` as the typed settings schema, Stylix provider, and package overlay
- replace the raw Niri KDL document with typed `programs.niri.settings`
- switch managed installations to `niri-unstable` and enable unstable Xwayland Satellite integration
- expose the selected Niri package's systemd user units while preserving `package = null` for system-provided Niri
- rely on pinned Niri defaults for redundant layout colors while Stylix supplies active and inactive border colors
- move screenshots into `~/Pictures/Screenshots`
- document the migration design and validation plan

## Why

The hand-written KDL configuration was difficult to maintain and could drift from Niri's schema. Typed settings provide option-level validation and generate a checked KDL file during evaluation. The unstable package pairing also enables Niri's integrated Xwayland Satellite support.

## Impact

Home Manager-managed sessions now use the pinned unstable Niri and Xwayland Satellite packages. Setting the wrapper package to `null` still generates and validates the configuration without installing Niri or its user units, allowing a system-provided session to remain in control.

Startup commands, window rules, environment variables, workspace bindings, UWSM integration, and non-Linux Home Manager evaluation remain supported.

## Validation

- `nix build --no-link '.#checks.x86_64-linux.formatting'`
- `nix build --no-link '.#homeConfigurations.mbx.activationPackage'`
- generated KDL validated with Niri 26.04
- managed and `package = null` branches evaluated for package and systemd-unit behavior
- generated binding parity checked against the previous KDL
- `pvg1-nixos` system build dry-run
- `home-mac` Home Manager build dry-run
