### PR TITLE
♻️ refactor: remove unused openclaw secrets

### DIFF
--- a/hosts/home-manager/macmini53/default.nix
+++ b/hosts/home-manager/macmini53/default.nix
@@ -57,13 +57,13 @@
 
   sops = {
     secrets = {
-      "openclaw/feishu/main/app_id".sopsFile = ./secrets.yaml;
-      "openclaw/feishu/main/app_secret".sopsFile = ./secrets.yaml;
+      "feishu/main/app_id".sopsFile = ./secrets.yaml;
+      "feishu/main/app_secret".sopsFile = ./secrets.yaml;
     };
 
     templates.cc-connect-env.content = ''
-      CC_CONNECT_FEISHU_APP_ID=${config.sops.placeholder."openclaw/feishu/main/app_id"}
-      CC_CONNECT_FEISHU_APP_SECRET=${config.sops.placeholder."openclaw/feishu/main/app_secret"}
+      CC_CONNECT_FEISHU_APP_ID=${config.sops.placeholder."feishu/main/app_id"}
+      CC_CONNECT_FEISHU_APP_SECRET=${config.sops.placeholder."feishu/main/app_secret"}
     '';
   };
 

--- a/hosts/home-manager/macmini53/secrets.yaml
+++ b/hosts/home-manager/macmini53/secrets.yaml
@@ -1,19 +1,7 @@
-openclaw:
-    token: ENC[AES256_GCM,data:CWnZCjZkw7Fo7ix8V64ghoI7/PJfAAdM0JiFtC3B0Kw/Ah3FAb6QxH11yW0kDh2D9hoTdEqz97RDAftv3YWLeA==,iv:MJ1yQWqUuXSzOFEWzdoZ3t9Ztk8Qjikh/H1lVBWHrTo=,tag:O0Cdf9s7jevjVlAW8zhK5Q==,type:str]
-    feishu:
-        main:
-            app_id: ENC[AES256_GCM,data:QAVAJqDnRol2qiQN3TfbMsWifxg=,iv:XG3CsLXptVaxE61hMZkzuCad8B8L6PJo0XJB90NPk/o=,tag:hmzpii8+Y4sYif8P2P3tAA==,type:str]
-            app_secret: ENC[AES256_GCM,data:8ikXzU9pSkirFWfJC06UxLxx7476M+MKqh1jA98XzJ8=,iv:90CiEOtNG7Y35RwhteNFlblBPnO2P2xtKEz3CtM5EK4=,tag:1mPy4bb2HYsD1NkxNPLfug==,type:str]
-        aurora:
-            app_id: ENC[AES256_GCM,data:vSMsoKCOGIBmousTz15dC7GEm54=,iv:6xp7i20ABqQXW4Gh1AYIljTgAjokARcD44lFHHhQY38=,tag:ZrShKfFXrRT4IN3xrWmGUw==,type:str]
-            app_secret: ENC[AES256_GCM,data:zIkNm1/nm6L8chFaewzDLBh+AP0LkMNk3ukag852KEU=,iv:dffOF7cEoMmm97qsOwQNMAHVmOW3eMKplDSEFG8K4lM=,tag:SSBxftqRkjR7bBZNo0hkog==,type:str]
-        ticos:
-            app_id: ENC[AES256_GCM,data:nvQuf7HR+3owYjF8l4Usc1HvNRw=,iv:5QBZKPBakqyyDkHRSY/yGxdAihgGbVNXVp69J0RJVv8=,tag:0NkNC1/Vcx/i2kZB6G//JA==,type:str]
-            app_secret: ENC[AES256_GCM,data:yPjxq+hw9Y8xYIInTMGdrUjLkoQ0ms/tBxFos4PebQ8=,iv:bX/+53Z4atZ9yMSG+qLicktVb7jEO/BOZcO6YNiTKAw=,tag:KNZ3bdEXONXz/iIG8ZrLgQ==,type:str]
-        zsflow:
-            app_id: ENC[AES256_GCM,data:TE/R2H5w4BhOacd1N1L69QZlyOA=,iv:i2uxUKZPG9fHgTYzHRQ0yU/Ald/BmD1FnRFIl8UvfMU=,tag:QPag0k6P9oYPyGPypHDvSA==,type:str]
-            app_secret: ENC[AES256_GCM,data:yvqiN7KY0K0bKyL5QRRP51krv8CUttRxhRUEQgU4XkY=,iv:2uizzxi4E8GsZRdzGRI9GotZ8J7QAMnm1bqgfTelKe4=,tag:vWj7ONE/C0yDwjKmXEXulw==,type:str]
-    zai_api_key: ENC[AES256_GCM,data:GkIVoXPhyD7wJbkjllloYL+NXTxs0EyeMqS67YPuuVc4ZeWpxMMHYGeafHPoDBMdSA==,iv:rI5gEqgsfmqFUA+8OeNOTh+svfS4qaoophkqFFVubGg=,tag:ZTkPucsZUJOAFJ8mWqGJBg==,type:str]
+feishu:
+    main:
+        app_id: ENC[AES256_GCM,data:QAVAJqDnRol2qiQN3TfbMsWifxg=,iv:XG3CsLXptVaxE61hMZkzuCad8B8L6PJo0XJB90NPk/o=,tag:hmzpii8+Y4sYif8P2P3tAA==,type:str]
+        app_secret: ENC[AES256_GCM,data:8ikXzU9pSkirFWfJC06UxLxx7476M+MKqh1jA98XzJ8=,iv:90CiEOtNG7Y35RwhteNFlblBPnO2P2xtKEz3CtM5EK4=,tag:1mPy4bb2HYsD1NkxNPLfug==,type:str]
 sops:
     age:
         - recipient: age1lhvvp7hnd8pweejp7804lznq65mz4zxjn4wut0zeyxs0vr7cgqrsd4emtx


### PR DESCRIPTION
## Summary
Remove unused openclaw secrets while keeping the required feishu/main credentials for cc-connect.

## Changes
- Keep feishu/main credentials for cc-connect
- Remove unused secrets (token, aurora, ticos, zsflow, zai_api_key)
- Update sops key paths from openclaw/feishu/main to feishu/main