### PR TITLE
🐛 fix: run kanata as root launch daemons

### DIFF
--- a/modules/nix-darwin/kanata/default.nix
+++ b/modules/nix-darwin/kanata/default.nix
@@ -5,36 +5,13 @@
   ...
 }:
 let
-  inherit (lib) getExe;
   cfg = config.nix-darwin.kanata;
-  driverKitExtVersion = "5.0.0";
+  driverKitExtVersion = "6.2.0";
+  kanataBin = "/run/current-system/sw/bin/kanata";
   kanataConfigFile = ../../../configs/kanata.kbd;
   karabinerDriverKitExtDestPath = "/Applications/.Karabiner-VirtualHIDDevice-Manager.app";
   karabinerFilesPath = "/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice";
-  kanataWrapper =
-    pkgs.writeShellScript "kanata-wrapper" # bash
-      ''
-        set -euo pipefail
-
-        echo "Starting kanata wrapper..."
-
-        # Start Karabiner daemon in background
-        exec sudo '${karabinerFilesPath}/Applications/Karabiner-VirtualHIDDevice-Daemon.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Daemon' &
-        echo "Started Karabiner daemon in background"
-
-        # Wait for daemon to initialize
-        sleep 2
-
-        # Verify daemon is running
-        if ! pgrep -f "Karabiner-VirtualHIDDevice-Daemon" > /dev/null; then
-            echo "Warning: Karabiner daemon may not have started properly"
-        fi
-
-        echo "Starting kanata..."
-
-        # Start Kanata (this becomes the main process)
-        exec sudo ${getExe pkgs.kanata} --cfg ${kanataConfigFile} --nodelay
-      '';
+  karabinerDaemon = "${karabinerFilesPath}/Applications/Karabiner-VirtualHIDDevice-Daemon.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Daemon";
 in
 {
   options.nix-darwin.kanata = {
@@ -44,6 +21,8 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.kanata ];
+
     system.activationScripts.applications.text =
       pkgs.lib.mkForce # bash
         ''
@@ -61,49 +40,56 @@ in
               echo "Current version found: $CURRENT_VERSION"
               echo "Destination path does not exist or version mismatch."
               echo "Installing Karabiner DriverKit VirtualHIDDevice..."
+              DRIVER_WAS_LOADED=0
+              KANATA_WAS_LOADED=0
+              if launchctl print "system/org.nixos.karabiner-virtualhiddevice-daemon" >/dev/null; then
+                DRIVER_WAS_LOADED=1
+                launchctl bootout "system/org.nixos.karabiner-virtualhiddevice-daemon"
+              fi
+              if launchctl print "system/org.nixos.kanata" >/dev/null; then
+                KANATA_WAS_LOADED=1
+                launchctl bootout "system/org.nixos.kanata"
+              fi
               /usr/sbin/installer -pkg "${pkgs.karabiner-driverkit-virtualhiddevice}/Karabiner-DriverKit-VirtualHIDDevice-${driverKitExtVersion}.pkg" -target /
               MACOS_PATH="$DEST_PATH/Contents/MacOS"
               echo "Removing quarantine attributes..."
               xattr -dr com.apple.quarantine "$DEST_PATH"
               echo activating dext...
               $MACOS_PATH/Karabiner-VirtualHIDDevice-Manager activate
-              printf '\x1b[0;31mPlease grant Input Monitoring permissions to ${pkgs.bash}/bin in System Preferences > Security & Privacy > Privacy > Input Monitoring\x1b[0m\n'
-              # use absolute path to force use of native macos stat
-              USER="$(/usr/bin/stat -f "%u" /dev/console)"
-              # should not already exist if service is created by this module (nix module cleans itself on uninstall)
-              if launchctl print "gui/$USER/org.nixos.kanata" >/dev/null; then
-                printf '\x1b[0;31mFound running kanata user agent. Unloading in case input monitoring permissions are missing on latest activation - will need to manually reload with..\x1b[0m\n'
-                printf '\x1b[0;31mlaunchctl bootstrap "gui/%s" "~/Library/LaunchAgents/org.nixos.kanata.plist"\x1b[0m\n' "$USER"
-                # Use sudo to run launchctl as the user who owns the GUI session
-                # best effort to unload the service if it's running
-                sudo -u "#$USER" launchctl bootout "gui/$USER/org.nixos.kanata" 2>/dev/null || true
-                printf '\x1b[0;31mAttempted to unload user agent with launchctl bootout...\x1b[0m\n'
+              if [ "$DRIVER_WAS_LOADED" -eq 1 ]; then
+                launchctl bootstrap "system" "/Library/LaunchDaemons/org.nixos.karabiner-virtualhiddevice-daemon.plist"
               fi
-              echo "Completed check for launchd agent for 'gui/$USER/org.nixos.kanata'"
+              if [ "$KANATA_WAS_LOADED" -eq 1 ]; then
+                launchctl bootstrap "system" "/Library/LaunchDaemons/org.nixos.kanata.plist"
+              fi
+              echo "Completed DriverKit service restart"
           fi
           echo "Completed Karabiner DriverKit VirtualHIDDevice activation"
         '';
 
-    # Create sudoers file for kanata to run without password
-    environment.etc."sudoers.d/kanata".source = pkgs.runCommand "sudoers-kanata" { } ''
-      KANATA_BIN="${getExe pkgs.kanata}"
-      KANATA_SHASUM=$(sha256sum "$KANATA_BIN" | cut -d' ' -f1)
-      KARABINER_DAEMON="${karabinerFilesPath}/Applications/Karabiner-VirtualHIDDevice-Daemon.app/Contents/MacOS/Karabiner-VirtualHIDDevice-Daemon"
-      KARABINER_DAEMON_ESCAPED=$(echo "$KARABINER_DAEMON" | sed 's/ /\\ /g')
-      cat <<EOF > "$out"
-      %admin ALL=(root) NOPASSWD: sha256:$KANATA_SHASUM $KANATA_BIN
-      %admin ALL=(root) NOPASSWD: $KARABINER_DAEMON_ESCAPED
-      EOF
-    '';
-
-    # User launch agent for kanata service
-    launchd.user.agents.kanata = {
-      command = "${kanataWrapper}";
+    launchd.daemons.karabiner-virtualhiddevice-daemon = {
       serviceConfig = {
+        ProgramArguments = [ karabinerDaemon ];
+        RunAtLoad = true;
         KeepAlive = true;
-        RunAtLoad = false;
-        StandardOutPath = "/tmp/kanata.out.log";
-        StandardErrorPath = "/tmp/kanata.err.log";
+        ProcessType = "Interactive";
+      };
+    };
+
+    launchd.daemons.kanata = {
+      serviceConfig = {
+        ProgramArguments = [
+          kanataBin
+          "--cfg"
+          "${kanataConfigFile}"
+          "--nodelay"
+        ];
+        RunAtLoad = true;
+        KeepAlive = true;
+        ProcessType = "Interactive";
+        Umask = 63;
+        StandardOutPath = "/var/log/kanata.out.log";
+        StandardErrorPath = "/var/log/kanata.err.log";
       };
     };
   };

--- a/modules/nix-darwin/kanata/default.nix
+++ b/modules/nix-darwin/kanata/default.nix
@@ -5,9 +5,9 @@
   ...
 }:
 let
+  inherit (lib) getExe;
   cfg = config.nix-darwin.kanata;
   driverKitExtVersion = "6.2.0";
-  kanataBin = "/run/current-system/sw/bin/kanata";
   kanataConfigFile = ../../../configs/kanata.kbd;
   karabinerDriverKitExtDestPath = "/Applications/.Karabiner-VirtualHIDDevice-Manager.app";
   karabinerFilesPath = "/Library/Application Support/org.pqrs/Karabiner-DriverKit-VirtualHIDDevice";
@@ -15,14 +15,12 @@ let
 in
 {
   options.nix-darwin.kanata = {
-    enable = lib.mkEnableOption "kanata sudoers configuration" // {
+    enable = lib.mkEnableOption "kanata launchd service" // {
       default = true;
     };
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.kanata ];
-
     system.activationScripts.applications.text =
       pkgs.lib.mkForce # bash
         ''
@@ -79,7 +77,7 @@ in
     launchd.daemons.kanata = {
       serviceConfig = {
         ProgramArguments = [
-          kanataBin
+          (getExe pkgs.kanata)
           "--cfg"
           "${kanataConfigFile}"
           "--nodelay"

--- a/packages/karabiner-driverkit-virtualhiddevice/default.nix
+++ b/packages/karabiner-driverkit-virtualhiddevice/default.nix
@@ -1,16 +1,15 @@
 {
   fetchurl,
   stdenv,
-  driverKitExtVersion ? "5.0.0",
+  driverKitExtVersion ? "6.2.0",
 }:
 
 stdenv.mkDerivation {
   pname = "Karabiner-DriverKit-VirtualHIDDevice";
   version = driverKitExtVersion;
-  # use /raw/main/dist/* from filetree
   src = fetchurl {
-    url = "https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/raw/main/dist/Karabiner-DriverKit-VirtualHIDDevice-${driverKitExtVersion}.pkg";
-    sha256 = "sha256-hKi2gmIdtjl/ZaS7RPpkpSjb+7eT0259sbUUbrn5mMc";
+    url = "https://github.com/pqrs-org/Karabiner-DriverKit-VirtualHIDDevice/releases/download/v${driverKitExtVersion}/Karabiner-DriverKit-VirtualHIDDevice-${driverKitExtVersion}.pkg";
+    sha256 = "sha256-noxGI58HSBYSQeQkRIV5ASJOXIL1tYoXMd9McL8HNqg=";
   };
 
   buildInputs = [ ];


### PR DESCRIPTION
## Summary

- Update Karabiner DriverKit VirtualHIDDevice to 6.2.0.
- Replace the primary-user Bash and sudo wrapper with separate root LaunchDaemons for DriverKit and Kanata.
- Execute Kanata directly from its immutable Nix store path, with root-only logs under `/var/log`.

## Why

The wrapper made Bash part of macOS TCC attribution, so a Bash package update invalidated the existing Accessibility grant. Direct launchd execution attributes keyboard access to Kanata itself. Using the immutable package path also ensures a Kanata upgrade changes the plist and makes nix-darwin reload the daemon with the new binary.

This intentionally makes the configured remapping machine-wide on this host.

## Validation

- Built `darwinConfigurations.t0.system` successfully.
- Ran targeted `nix fmt`, Statix, whitespace, generated-plist, and DriverKit artifact-hash checks.
- Activated both system LaunchDaemons with DriverKit 6.2.0 and Kanata 1.12.0 running as UID 0.
- Confirmed stable PIDs and run counts, root-owned mode-`0600` logs, and no planned failure-pattern matches.
- Confirmed fresh TCC attribution names Kanata rather than Bash or sudo.
- Confirmed the Caps Lock to Escape remap works on the live host.

## Documentation

No documentation update is needed: the existing `nix-darwin.kanata.enable` interface is unchanged, and the repository has no Kanata-specific user documentation to update.
