### PR TITLE
Stabilize Claude Code plugin name

### DIFF
--- a/modules/home-manager/dev/coding-agents/codex.nix
+++ b/modules/home-manager/dev/coding-agents/codex.nix
@@ -48,7 +48,7 @@ in
       enable = true;
       enableMcpIntegration = true;
       package = codexPackage;
-      inherit (shared) plugins;
+      plugins = shared.pluginSources;
       rules.basic = basicRules;
       hooks = lib.optionalAttrs config.home-manager.cli.jujutsu.enable {
         Stop = [

--- a/modules/home-manager/dev/coding-agents/shared.nix
+++ b/modules/home-manager/dev/coding-agents/shared.nix
@@ -30,15 +30,16 @@ let
   };
 
   # Plugins - defined once, used across tools
-  plugins = [
-    (pkgs.fetchFromGitHub {
+  plugins = {
+    beads-superpowers = pkgs.fetchFromGitHub {
       name = "beads-superpowers";
       owner = "DollarDill";
       repo = "beads-superpowers";
       rev = "v0.15.0";
       hash = "sha256-zT56CUynU+bjlC2F5LsfiFyX3aQ+OLNCMPxzq/Rwr4A=";
-    })
-  ];
+    };
+  };
+  pluginSources = lib.attrValues plugins;
 
   # Extract skills embedded inside plugins
   pluginSkills = lib.foldl' (
@@ -47,7 +48,7 @@ let
       skillsDir = plugin + "/skills";
     in
     if builtins.pathExists skillsDir then acc // loadSkills skillsDir else acc
-  ) { } plugins;
+  ) { } pluginSources;
 
   # All skills combined
   allSkills = jujutsuSkills // obsidianSkills // localSkills // pluginSkills;
@@ -88,6 +89,7 @@ in
     localSkills
     pluginSkills
     plugins
+    pluginSources
     loadSkills
     permissions
     yeggeInstructions


### PR DESCRIPTION
## Summary

- represent shared plugins as a named attribute set so Claude Code installs `beads-superpowers` under a stable directory name
- derive the list form once for Codex and embedded plugin skill discovery
- preserve the existing plugin source, revision, hash, and skill precedence

## Root cause

Home Manager still accepts a list for `programs.claude-code.plugins`, but derives plugin names from list-entry basenames. A fetched Nix store path therefore produces an unstable directory name and emits a deprecation warning. Claude Code accepts a named attribute set, while Codex requires a list.

## Impact

Claude Code now installs the existing plugin as `beads-superpowers` without the legacy-list warning. Codex and embedded skill discovery continue using the identical pinned source.

## Validation

- reproduced the pre-change Claude Code plugin-list warning
- verified Claude Code evaluates to an attribute set with exactly the `beads-superpowers` key
- verified Codex evaluates to a one-element list containing the same store path
- verified the post-change t0 evaluation no longer emits the plugin-list warning
- `nix fmt modules/home-manager/dev/coding-agents/shared.nix modules/home-manager/dev/coding-agents/codex.nix`
- `statix check` on both changed files
- `git diff --check`
- `nix build --no-link --print-out-paths '.#darwinConfigurations.t0.system'`
